### PR TITLE
Data Upload and View in Table implemented

### DIFF
--- a/app.R
+++ b/app.R
@@ -21,7 +21,11 @@ ui <- fluidPage(
    sidebarLayout(
       sidebarPanel(
           conditionalPanel(condition="input.tabSelected==1",h5("This is Tab 1")),
-          conditionalPanel(condition = "input.tabSelected==2",h5("This is Tab 2")),
+          conditionalPanel(condition = "input.tabSelected==2",h5("This is Tab 2"),
+                           fileInput("file", "Upload file"),
+                           h5("Max file size is 5MB"),
+                           radioButtons("sep","Separator", choices = c(Comma = ',', Period = ".", Tilde = "~", Minus = "-")),
+                           checkboxInput("header","Header?")),
           conditionalPanel(condition = "input.tabSelected==3",h5("This is Tab 3"), sliderInput("bins",
                      "Number of bins:",
                      min = 1,
@@ -47,7 +51,7 @@ ui <- fluidPage(
                                pharetra lobortis risus efficitur. Aliquam vitae ipsum malesuada, rhoncus sem et, pellentesque erat. 
                                Duis sed sem vel odio fringilla eleifend ut sit amet ex. Fusce eleifend, odio eu faucibus iaculis, 
                                     mi ligula fermentum velit, sit amet lacinia arcu mi at risus. Nam vitae tristique nibh.")),
-                      tabPanel("Data Upload", value=2, conditionalPanel(condition = "input.choice==2")),
+                      tabPanel("Data Upload", value=2, conditionalPanel(condition = "input.choice==2"),tableOutput("inputFile")),
                       tabPanel("Data Visualization",value=3, conditionalPanel(condition = "input.choice==3"), plotOutput("distPlot")),
                       id = "tabSelected"
           )
@@ -71,6 +75,18 @@ server <- function(input, output) {
       
       # draw the histogram with the specified number of bins
       hist(x, breaks = bins, col = 'darkgray', border = 'white')
+   })
+   
+   #Function to read in a data file and display in data file
+   output$inputFile <- renderTable({
+       
+       file.to.read = input$file
+       if (is.null(file.to.read)){
+           return()
+       }
+       
+       read.table(file.to.read$datapath, sep = input$sep, header = input$header)
+       
    })
 }
 

--- a/app.R
+++ b/app.R
@@ -34,13 +34,14 @@ ui <- fluidPage(
           tabsetPanel(type = "tab",
                       
                       tabPanel("About", value=1, conditionalPanel(condition = "input.choice==1"),
-                            h5("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce maximus orci vitae erat commodo tincidunt. 
+                               
+                                p("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce maximus orci vitae erat commodo tincidunt. 
                                Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Quisque lobortis, 
                                metus sit amet volutpat mollis, velit ex lobortis ligula, non hendrerit risus nulla eu risus. Praesent et ultrices orci,
                                et molestie sem. Suspendisse elementum mauris eleifend dolor vestibulum interdum. Aenean mauris odio, efficitur in libero in,
                                aliquam venenatis metus. Nunc at accumsan metus. Donec non dui vitae nulla sodales lobortis at sit amet quam. 
                                Duis pellentesque odio a porta posuere."),
-                            h5("Quisque urna libero, dapibus sed nibh pretium, congue vestibulum urna. Aliquam elementum nisl quis nibh porta varius.
+                                p("Quisque urna libero, dapibus sed nibh pretium, congue vestibulum urna. Aliquam elementum nisl quis nibh porta varius.
                                Etiam malesuada, arcu nec iaculis sollicitudin, lacus purus aliquet ipsum, sit amet dapibus arcu mi vitae turpis.
                                Nam ut est quis neque porta aliquam ut eget augue. Nulla ut semper dui. Donec luctus lectus ut risus consequat,
                                pharetra lobortis risus efficitur. Aliquam vitae ipsum malesuada, rhoncus sem et, pellentesque erat. 

--- a/app.R
+++ b/app.R
@@ -20,13 +20,13 @@ ui <- fluidPage(
    # Sidebar that changes depending on which tab is selected
    sidebarLayout(
       sidebarPanel(
-          conditionalPanel(condition="input.tabSelected==1",h5("This is Tab 1")),
-          conditionalPanel(condition = "input.tabSelected==2",h5("This is Tab 2"),
+          conditionalPanel(condition="input.tabSelected==1",h5("Insert Text Here")),
+          conditionalPanel(condition = "input.tabSelected==2",
                            fileInput("file", "Upload file"),
                            h5("Max file size is 5MB"),
                            radioButtons("sep","Separator", choices = c(Comma = ',', Period = ".", Tilde = "~", Minus = "-")),
-                           checkboxInput("header","Header?")),
-          conditionalPanel(condition = "input.tabSelected==3",h5("This is Tab 3"), sliderInput("bins",
+                           checkboxInput("header","Initial Header Line")),
+          conditionalPanel(condition = "input.tabSelected==3", sliderInput("bins",
                      "Number of bins:",
                      min = 1,
                      max = 50,


### PR DESCRIPTION
Hi Prof, The "Data Upload" tab now has the functionality to upload a csv, choose the delimiter and indicate whether or not the data has a header line. Once the data is uploaded either by choosing the path to the file or by dragging and dropping the file in browse field, the data is displayed in a table. 

I have used some common files such as mtcars.csv, faithful.csv and iris.csv to test it. I have uploaded a zip file with the files I used to test. Please try others to see if there are any issues. The default maximum size that a file can be uploaded is currently 5MB. Is this adequate? I have read that it can be increased but more investigating will be required to implement it. Should this be implemented now or can I come back to it at a later stage once some of the graphing functionality is complete?

The error handling to see if the file is compliant with a dataframe seems to be built in when trying to display it in the table. Do I need to still write my own or expand the existing checks and error messages?

Any other comments, criticism or recommendations are welcome.

Thanks




[Testing Datasets.zip](https://github.com/kamermanpr/shinyPlotR/files/1518066/Testing.Datasets.zip)
