### PR TITLE
Feature data upload improvements

### DIFF
--- a/app.R
+++ b/app.R
@@ -25,7 +25,11 @@ ui <- fluidPage(
           conditionalPanel(condition = "input.tabSelected==2",
                            fileInput("file", "Upload file"),
                            h5("Max file size is 5MB"),
-                           radioButtons("sep","Separator", choices = c(Comma = ',', Period = ".", Tilde = "~", Minus = "-"))),
+                           radioButtons("sep","Separator", choices = c(Comma = ',', Period = ".", Tilde = "~", Minus = "-")),
+                           numericInput(inputId = "rows",
+                                        label = "Number of rows to view:",
+                                        min = 0,
+                                        value = 10)),
           conditionalPanel(condition = "input.tabSelected==3", sliderInput("bins",
                      "Number of bins:",
                      min = 1,
@@ -77,18 +81,22 @@ server <- function(input, output) {
       hist(x, breaks = bins, col = 'darkgray', border = 'white')
    })
    
-   #Function to read in a data file and display in data file
-   output$inputFile <- renderTable({
-       
+   df <- reactive({
        file_to_read = input$file
        if (is.null(file_to_read)){
            return()
        }
        
        read_delim(file_to_read$datapath, input$sep)
-       #read.table(file.to.read$datapath, sep = input$sep, header = input$header)
-       
    })
+
+   
+   output$inputFile <- renderTable({
+       head(df(),  n = input$rows)
+   })
+   
+   
+   
 }
 
 ############################################################

--- a/app.R
+++ b/app.R
@@ -89,17 +89,21 @@ server <- function(input, output) {
       hist(x, breaks = bins, col = 'darkgray', border = 'white')
    })
    
+   ################
+   #  UPLOAD TAB  #
+   ################
+   
    # Generate reactive dataframe object
    df <- reactive({
        if(is.null(input$file)) {
            return()
-           } else {
-               readr::read_delim(file = input$file$datapath, 
-                                 delim = input$sep)
-               }
-       })
-    
-    # Waiting message
+       } else {
+           readr::read_delim(file = input$file$datapath, 
+                             delim = input$sep)
+       }
+   })
+   
+   # Waiting message
    output$waiting <- renderPrint({
        if(!is.null(df())) {
            tags$p("")

--- a/app.R
+++ b/app.R
@@ -5,6 +5,7 @@
 ############################################################
 # Load packages
 library(shiny)
+library(tidyverse)
 
 ############################################################
 #                                                          #
@@ -24,8 +25,7 @@ ui <- fluidPage(
           conditionalPanel(condition = "input.tabSelected==2",
                            fileInput("file", "Upload file"),
                            h5("Max file size is 5MB"),
-                           radioButtons("sep","Separator", choices = c(Comma = ',', Period = ".", Tilde = "~", Minus = "-")),
-                           checkboxInput("header","Initial Header Line")),
+                           radioButtons("sep","Separator", choices = c(Comma = ',', Period = ".", Tilde = "~", Minus = "-"))),
           conditionalPanel(condition = "input.tabSelected==3", sliderInput("bins",
                      "Number of bins:",
                      min = 1,
@@ -80,12 +80,13 @@ server <- function(input, output) {
    #Function to read in a data file and display in data file
    output$inputFile <- renderTable({
        
-       file.to.read = input$file
-       if (is.null(file.to.read)){
+       file_to_read = input$file
+       if (is.null(file_to_read)){
            return()
        }
        
-       read.table(file.to.read$datapath, sep = input$sep, header = input$header)
+       read_delim(file_to_read$datapath, input$sep)
+       #read.table(file.to.read$datapath, sep = input$sep, header = input$header)
        
    })
 }

--- a/app.R
+++ b/app.R
@@ -25,7 +25,11 @@ ui <- fluidPage(
           conditionalPanel(condition = "input.tabSelected==2",
                            fileInput("file", "Upload file"),
                            h5("Max file size is 5MB"),
-                           radioButtons("sep","Separator", choices = c(Comma = ',', Period = ".", Tilde = "~", Minus = "-"))),
+                           radioButtons("sep","Separator", choices = c(Comma = ',', Period = ".", Tilde = "~", Minus = "-")),
+                           numericInput(inputId = "rows",
+                                        label = "Number of rows to view:",
+                                        min = 0,
+                                        value = 10)),
           conditionalPanel(condition = "input.tabSelected==3", sliderInput("bins",
                      "Number of bins:",
                      min = 1,
@@ -51,8 +55,12 @@ ui <- fluidPage(
                                pharetra lobortis risus efficitur. Aliquam vitae ipsum malesuada, rhoncus sem et, pellentesque erat. 
                                Duis sed sem vel odio fringilla eleifend ut sit amet ex. Fusce eleifend, odio eu faucibus iaculis, 
                                     mi ligula fermentum velit, sit amet lacinia arcu mi at risus. Nam vitae tristique nibh.")),
-                      tabPanel("Data Upload", value=2, conditionalPanel(condition = "input.choice==2"),tableOutput("inputFile")),
-                      tabPanel("Data Visualization",value=3, conditionalPanel(condition = "input.choice==3"), plotOutput("distPlot")),
+                      tabPanel("Data Upload", value=2,
+                               conditionalPanel(condition = "input.choice==2"),
+                               tableOutput("inputFile")),
+                      tabPanel("Data Visualization",value=3, 
+                               conditionalPanel(condition = "input.choice==3"), 
+                               plotOutput("distPlot")),
                       id = "tabSelected"
           )
       )
@@ -77,18 +85,25 @@ server <- function(input, output) {
       hist(x, breaks = bins, col = 'darkgray', border = 'white')
    })
    
-   #Function to read in a data file and display in data file
-   output$inputFile <- renderTable({
-       
+   df <- reactive({
        file_to_read = input$file
        if (is.null(file_to_read)){
            return()
+       } else {
+           read_delim(file_to_read$datapath, input$sep)
        }
        
-       read_delim(file_to_read$datapath, input$sep)
-       #read.table(file.to.read$datapath, sep = input$sep, header = input$header)
        
    })
+
+   
+   output$inputFile <- renderTable({
+      head(df(),  n = input$rows)
+   })
+   
+   
+   
+   
 }
 
 ############################################################


### PR DESCRIPTION
Hi Prof,

I made some adjustments to the data upload tab. The improvements I made revolve around the suggestions that you made on the last pull request. 

It now uses the readr package with read_delim. It seems to take longer however, not too sure why. But when I run it in the browser its really quick. Is it better to call the function like a) read_delim() or b) readr::read_delim() ?

It now displays the number of rows and columns that the csv file contains once uploaded. It also defaults to showing a maximum of 10 rows of the table. This can be adjusted using the numeric input found in the sideBarPanel. It might need some improvement to deal when the csv contains less than 10 rows.

I also had a look and implemented the glimpse function for dplyr package. The output seemed a bit messy and redundant as I show the rows and columns, and the first 10 rows of the data. I therefore commented out these parts for the time being.

I think moving forward I can begin work on the plotting of the data. Should I do this or something else? 

Do you have any other recommendations or suggestions?

Thanks